### PR TITLE
fix: Pass UI config to default UI

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,7 +3,7 @@ import { BitmovinPlayer, CustomUi } from 'bitmovin-player-react';
 import { ControlBar, PlaybackToggleOverlay, SeekBar, UIContainer, UIVariant } from 'bitmovin-player-ui';
 import { Fragment } from 'react';
 
-import { config } from './config.js';
+import { config } from './config.dist.ts';
 
 const defaultPlayerSource: SourceConfig = {
   hls: 'https://cdn.bitmovin.com/content/assets/streams-sample-video/sintel/m3u8/index.m3u8',

--- a/src/BitmovinPlayer.tsx
+++ b/src/BitmovinPlayer.tsx
@@ -155,7 +155,7 @@ function initializePlayerUi(player: PlayerAPI, playerConfig: PlayerConfig, custo
   else if (customUi && 'variantsFactory' in customUi) {
     new UIManager(player, customUi.variantsFactory(), playerConfig.ui);
   } else {
-    UIFactory.buildDefaultUI(player);
+    UIFactory.buildDefaultUI(player, playerConfig.ui);
   }
 }
 


### PR DESCRIPTION
### Problem
The UI config defined in `playerConfig.ui` is not forwarded to the default UI, i.e. when no `customUi` property is defined on the BitmovinPlayer component.

### Changes
- Pass UI config to default UI builder
- Fix config import