### PR TITLE
fix: cleanup player-ui before destroying player on unmount

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,7 @@
 import { PlayerConfig, SourceConfig } from 'bitmovin-player';
 import { BitmovinPlayer, CustomUi } from 'bitmovin-player-react';
 import { ControlBar, PlaybackToggleOverlay, SeekBar, UIContainer, UIVariant } from 'bitmovin-player-ui';
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 
 import { config } from './config.dist.ts';
 
@@ -44,6 +44,8 @@ const customUi: CustomUi = {
 };
 
 export function App() {
+  const [showPlayer, setShowPlayer] = useState(true);
+
   return (
     <Fragment>
       <h1>Bitmovin Player React Demo</h1>
@@ -53,8 +55,9 @@ export function App() {
           maxWidth: '800px',
         }}
       >
-        <BitmovinPlayer source={defaultPlayerSource} config={playerConfig} customUi={customUi} />
+        {showPlayer && <BitmovinPlayer source={defaultPlayerSource} config={playerConfig} customUi={customUi} />}
       </div>
+      <button onClick={() => setShowPlayer(!showPlayer)}>Toggle Player</button>
     </Fragment>
   );
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -49,6 +49,9 @@ export function App() {
   return (
     <Fragment>
       <h1>Bitmovin Player React Demo</h1>
+      <button className="toggle-player" onClick={() => setShowPlayer(!showPlayer)}>
+        Toggle Player
+      </button>
       <div
         style={{
           position: 'relative',
@@ -57,7 +60,6 @@ export function App() {
       >
         {showPlayer && <BitmovinPlayer source={defaultPlayerSource} config={playerConfig} customUi={customUi} />}
       </div>
-      <button onClick={() => setShowPlayer(!showPlayer)}>Toggle Player</button>
     </Fragment>
   );
 }

--- a/example/src/customStyles.css
+++ b/example/src/customStyles.css
@@ -1,3 +1,7 @@
 .bmpui-ui-seekbar .bmpui-seekbar .bmpui-seekbar-playbackposition-marker {
   border-color: red;
 }
+
+.toggle-player {
+  margin-bottom: 1rem;
+}

--- a/src/BitmovinPlayer.test.tsx
+++ b/src/BitmovinPlayer.test.tsx
@@ -279,6 +279,41 @@ describe('BitmovinPlayer', () => {
         expect(getBySelector(selector)).not.toBeInTheDocument();
       });
     });
+
+    describe('Cleanup', () => {
+      it('should properly clean up the UI manager before destroying the player', async () => {
+        const uiManagerReleaseSpy = jest.spyOn(UIManager.prototype, 'release');
+        const playerDestroySpy = jest.spyOn(FakePlayer.prototype, 'destroy');
+
+        const { unmount } = render(<BitmovinPlayer config={playerConfig} />);
+
+        unmount();
+
+        // Verify that release() is called before destroy()
+        expect(uiManagerReleaseSpy).toHaveBeenCalledTimes(1);
+        expect(playerDestroySpy).toHaveBeenCalledTimes(1);
+        expect(uiManagerReleaseSpy.mock.invocationCallOrder[0]).toBeLessThan(
+          playerDestroySpy.mock.invocationCallOrder[0],
+        );
+      });
+
+      it('should not attempt to release UI manager if UI is disabled', () => {
+        const uiManagerReleaseSpy = jest.spyOn(UIManager.prototype, 'release');
+
+        const { unmount } = render(
+          <BitmovinPlayer
+            config={{
+              ...playerConfig,
+              ui: false,
+            }}
+          />,
+        );
+
+        unmount();
+
+        expect(uiManagerReleaseSpy).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('Ref', () => {
@@ -383,41 +418,6 @@ describe('BitmovinPlayer', () => {
       await expectNeverOccurs(() => {
         expect(FakePlayer.prototype.unload).toHaveBeenCalled();
       });
-    });
-  });
-
-  describe('UI cleanup', () => {
-    it('should properly clean up the UI manager before destroying the player', async () => {
-      const uiManagerReleaseSpy = jest.spyOn(UIManager.prototype, 'release');
-      const playerDestroySpy = jest.spyOn(FakePlayer.prototype, 'destroy');
-
-      const { unmount } = render(<BitmovinPlayer config={playerConfig} />);
-
-      unmount();
-
-      // Verify that release() is called before destroy()
-      expect(uiManagerReleaseSpy).toHaveBeenCalledTimes(1);
-      expect(playerDestroySpy).toHaveBeenCalledTimes(1);
-      expect(uiManagerReleaseSpy.mock.invocationCallOrder[0]).toBeLessThan(
-        playerDestroySpy.mock.invocationCallOrder[0],
-      );
-    });
-
-    it('should not attempt to release UI manager if UI is disabled', () => {
-      const uiManagerReleaseSpy = jest.spyOn(UIManager.prototype, 'release');
-
-      const { unmount } = render(
-        <BitmovinPlayer
-          config={{
-            ...playerConfig,
-            ui: false,
-          }}
-        />,
-      );
-
-      unmount();
-
-      expect(uiManagerReleaseSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/BitmovinPlayer.test.tsx
+++ b/src/BitmovinPlayer.test.tsx
@@ -10,7 +10,7 @@ jest.mock('bitmovin-player', () => {
 import { render, waitFor } from '@testing-library/react';
 import { PlayerAPI, PlayerConfig, SourceConfig } from 'bitmovin-player';
 import { PlaybackToggleOverlay, TitleBar, UIContainer } from 'bitmovin-player-ui';
-import { UIVariant } from 'bitmovin-player-ui/dist/js/framework/uimanager.js';
+import { UIManager, UIVariant } from 'bitmovin-player-ui/dist/js/framework/uimanager.js';
 import { MutableRefObject, RefCallback, StrictMode } from 'react';
 
 import { BitmovinPlayer } from './BitmovinPlayer.js';
@@ -383,6 +383,41 @@ describe('BitmovinPlayer', () => {
       await expectNeverOccurs(() => {
         expect(FakePlayer.prototype.unload).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('UI cleanup', () => {
+    it('should properly clean up the UI manager before destroying the player', async () => {
+      const uiManagerReleaseSpy = jest.spyOn(UIManager.prototype, 'release');
+      const playerDestroySpy = jest.spyOn(FakePlayer.prototype, 'destroy');
+
+      const { unmount } = render(<BitmovinPlayer config={playerConfig} />);
+
+      unmount();
+
+      // Verify that release() is called before destroy()
+      expect(uiManagerReleaseSpy).toHaveBeenCalledTimes(1);
+      expect(playerDestroySpy).toHaveBeenCalledTimes(1);
+      expect(uiManagerReleaseSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        playerDestroySpy.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('should not attempt to release UI manager if UI is disabled', () => {
+      const uiManagerReleaseSpy = jest.spyOn(UIManager.prototype, 'release');
+
+      const { unmount } = render(
+        <BitmovinPlayer
+          config={{
+            ...playerConfig,
+            ui: false,
+          }}
+        />,
+      );
+
+      unmount();
+
+      expect(uiManagerReleaseSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/BitmovinPlayer.tsx
+++ b/src/BitmovinPlayer.tsx
@@ -212,7 +212,6 @@ function destroyPlayer(
   // First destroy the UI manager if it exists
   if (uiManager) {
     uiManager.release();
-    uiManager = undefined;
   }
 
   // Then destroy the player

--- a/src/BitmovinPlayer.tsx
+++ b/src/BitmovinPlayer.tsx
@@ -142,6 +142,8 @@ function setRef<T>(ref: RefCallback<T> | MutableRefObject<T>, value: T) {
   }
 }
 
+let uiManager: UIManager | undefined;
+
 function initializePlayerUi(player: PlayerAPI, playerConfig: PlayerConfig, customUi?: BitmovinPlayerProps['customUi']) {
   if (playerConfig.ui === false) {
     return;
@@ -149,13 +151,13 @@ function initializePlayerUi(player: PlayerAPI, playerConfig: PlayerConfig, custo
 
   // If a custom UI container is provided, use it instead of the default UI.
   if (customUi && 'containerFactory' in customUi) {
-    new UIManager(player, customUi.containerFactory(), playerConfig.ui);
+    uiManager = new UIManager(player, customUi.containerFactory(), playerConfig.ui);
   }
   // If custom UI variants are provided, use them instead of the default UI.
   else if (customUi && 'variantsFactory' in customUi) {
-    new UIManager(player, customUi.variantsFactory(), playerConfig.ui);
+    uiManager = new UIManager(player, customUi.variantsFactory(), playerConfig.ui);
   } else {
-    UIFactory.buildDefaultUI(player, playerConfig.ui);
+    uiManager = UIFactory.buildDefaultUI(player, playerConfig.ui);
   }
 }
 
@@ -208,5 +210,12 @@ function destroyPlayer(
     rootContainerElement.removeChild(playerContainerElement);
   };
 
+  // First destroy the UI manager if it exists
+  if (uiManager) {
+    uiManager.release();
+    uiManager = undefined;
+  }
+
+  // Then destroy the player
   player.destroy().then(removePlayerContainerElement, removePlayerContainerElement);
 }

--- a/src/BitmovinPlayer.tsx
+++ b/src/BitmovinPlayer.tsx
@@ -89,7 +89,7 @@ export const BitmovinPlayer = forwardRef(function BitmovinPlayer(
     const convertedConfig = convertConfig(config);
     const initializedPlayer = initializePlayer(createdPlayerContainerElement, createdVideoElement, convertedConfig);
 
-    initializePlayerUi(initializedPlayer, config, customUi);
+    const uiManager = initializePlayerUi(initializedPlayer, config, customUi);
 
     latestPlayerRef.current = initializedPlayer;
 
@@ -97,7 +97,7 @@ export const BitmovinPlayer = forwardRef(function BitmovinPlayer(
     setPlayer(initializedPlayer);
 
     return () => {
-      destroyPlayer(initializedPlayer, rootContainerElement, createdPlayerContainerElement);
+      destroyPlayer(initializedPlayer, rootContainerElement, createdPlayerContainerElement, uiManager);
     };
   }, [config, customUi, proxyPlayerRef]);
 
@@ -142,8 +142,6 @@ function setRef<T>(ref: RefCallback<T> | MutableRefObject<T>, value: T) {
   }
 }
 
-let uiManager: UIManager | undefined;
-
 function initializePlayerUi(player: PlayerAPI, playerConfig: PlayerConfig, customUi?: BitmovinPlayerProps['customUi']) {
   if (playerConfig.ui === false) {
     return;
@@ -151,13 +149,13 @@ function initializePlayerUi(player: PlayerAPI, playerConfig: PlayerConfig, custo
 
   // If a custom UI container is provided, use it instead of the default UI.
   if (customUi && 'containerFactory' in customUi) {
-    uiManager = new UIManager(player, customUi.containerFactory(), playerConfig.ui);
+    return new UIManager(player, customUi.containerFactory(), playerConfig.ui);
   }
   // If custom UI variants are provided, use them instead of the default UI.
   else if (customUi && 'variantsFactory' in customUi) {
-    uiManager = new UIManager(player, customUi.variantsFactory(), playerConfig.ui);
+    return new UIManager(player, customUi.variantsFactory(), playerConfig.ui);
   } else {
-    uiManager = UIFactory.buildDefaultUI(player, playerConfig.ui);
+    return UIFactory.buildDefaultUI(player, playerConfig.ui);
   }
 }
 
@@ -203,6 +201,7 @@ function destroyPlayer(
   player: PlayerAPI,
   rootContainerElement: HTMLDivElement,
   playerContainerElement: HTMLDivElement,
+  uiManager: UIManager | undefined,
 ) {
   playerContainerElement.style.display = 'none';
 

--- a/src/testUtils/FakePlayer.ts
+++ b/src/testUtils/FakePlayer.ts
@@ -12,6 +12,7 @@ export class FakePlayer
     Pick<
       PlayerModule.PlayerAPI,
       | 'on'
+      | 'off'
       | 'load'
       | 'getSource'
       | 'unload'
@@ -56,6 +57,8 @@ export class FakePlayer
   }
 
   on() {}
+
+  off() {}
 
   getContainer() {
     return this.containerElement;


### PR DESCRIPTION
Hi all, I raised this as a [Bitmovin Support Ticket](https://bitmovin.zendesk.com/hc/en-us/requests/22796) last month. I was told it would be raised internally but I had some time to attempt a fix. Let me know if you spot anything that's amiss

## Please describe the unexpected behavior you are experiencing:

There is an error is thrown from the Bitmovin player script when unmounting the component

```
{
  "code": 1001,
  "name": "API_NOT_AVAILABLE",
  "message": "Cannot use the `player.isCasting` API: the player has already been destroyed."
}
```

## Please outline how you expect it should work:

The player's cleanup should not destroy the player prior to other resources being cleaned up

## Please provide the steps to reliably reproduce this issue:

Open the browser console, click button to unmount player
https://stackblitz.com/edit/bitmovin-player-react-bug-report?file=src%2FApp.tsx