### PR TITLE
feat: support for Player UI v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for Bitmovin Player Web UI v4
+- Support for StyleConfig.uiManagerFactory which is available since Player 8.226.0
+
 ## 1.0.3 - 2024-12-17
 
 - Update the attach events example in the README.md

--- a/README.md
+++ b/README.md
@@ -194,6 +194,39 @@ export function MyComponent() {
 
 ## Customize player UI
 
+This library supports both `bitmovin-player-ui` v3 and v4. The version is automatically detected at runtime based on which version you install in your project.
+
+To control which version is used, specify it in your `package.json`:
+
+```json
+{
+  "dependencies": {
+    "bitmovin-player-ui": "^3.104.0"  // for v3
+    // or
+    "bitmovin-player-ui": "^4.0.0"    // for v4
+  }
+}
+```
+
+For `bitmovin-player` versions 8.226.0 and above, you can also use `StyleConfig.uiManagerFactory` to provide a custom UI manager factory directly in the player configuration:
+
+```tsx
+import { PlayerConfig } from "bitmovin-player";
+import { UIManager } from "bitmovin-player-ui";
+
+const playerConfig: PlayerConfig = {
+  key: "<key>",
+  styleConfig: {
+    uiManagerFactory: (player, uiConfig) => {
+      // Return your custom UIManager instance
+      return new UIManager(player, yourCustomUIContainer, uiConfig);
+    }
+  }
+};
+```
+
+**Note:** The `styleConfig.uiManagerFactory` option requires `bitmovin-player` 8.226.0 or higher.
+
 ### Use UI container
 
 You can use `UIContainer` from https://www.npmjs.com/package/bitmovin-player-ui to customize the player UI:
@@ -271,6 +304,42 @@ export function MyComponent() {
   );
 }
 ```
+
+### Use custom UIManager factory
+
+You can provide a custom `UIManager` factory function to have full control over UI initialization:
+
+```tsx
+import { PlayerAPI, UIConfig } from "bitmovin-player";
+import { UIManager, UIContainer, PlaybackToggleOverlay, CustomUi } from "bitmovin-player-ui";
+
+const uiManagerFactory = (player: PlayerAPI, config: UIConfig): UIManager => {
+  const customContainer = new UIContainer({
+    components: [new PlaybackToggleOverlay()],
+  });
+
+  return new UIManager(player, customContainer, config);
+};
+
+const customUi: CustomUi = {
+  managerFactory: uiManagerFactory
+};
+
+export function MyComponent() {
+  return (
+    <Fragment>
+      <h1>Custom UIManager factory demo</h1>
+      <BitmovinPlayer
+        source={playerSource}
+        config={playerConfig}
+        customUi={customUi}
+      />
+    </Fragment>
+  );
+}
+```
+
+This approach gives you the most flexibility, as you can customize both the UI container and the UIManager initialization logic.
 
 ### Use custom CSS
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "bitmovin-player": "^8.159.0",
         "bitmovin-player-react": "file:..",
-        "bitmovin-player-ui": "^3.60.0",
+        "bitmovin-player-ui": "^4.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -19,8 +19,7 @@
       }
     },
     "..": {
-      "name": "bitmovin-player-react",
-      "version": "1.0.0-beta.2",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",
@@ -49,7 +48,7 @@
       },
       "peerDependencies": {
         "bitmovin-player": "^8.0.0",
-        "bitmovin-player-ui": "^3.60.0",
+        "bitmovin-player-ui": "^3 || ^4",
         "react": "^17.0.0 || ^18.0.0"
       }
     },
@@ -1131,9 +1130,10 @@
       "link": true
     },
     "node_modules/bitmovin-player-ui": {
-      "version": "3.60.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player-ui/-/bitmovin-player-ui-3.60.0.tgz",
-      "integrity": "sha512-NlLotUplZRw6YU488IvmoWRNnonFGUp4yPsvBn7VCYteg5Z3LEk08kkU+i5jUhR4NMzMu//cF68KA4hwIcQFJQ=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player-ui/-/bitmovin-player-ui-4.5.0.tgz",
+      "integrity": "sha512-SMyCqL1o1+h4KQChnSeka6vaPzMkWH9plg61FlLEUOespY+ZeVeCGsAUpZVPT/gDdaiZ98W7u/C5C0Nak79roA==",
+      "license": "MIT"
     },
     "node_modules/browserslist": {
       "version": "4.23.0",

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "bitmovin-player": "^8.159.0",
     "bitmovin-player-react": "file:..",
-    "bitmovin-player-ui": "^3.60.0",
+    "bitmovin-player-ui": "^4.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2394,9 +2394,9 @@
       "dev": true
     },
     "node_modules/bitmovin-player": {
-      "version": "8.161.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.161.0.tgz",
-      "integrity": "sha512-P5sx3KOW4FH23abGOzhDmJHIq1KXXzQpd6MFPmKNDD849p2DKkThxXOyTafQdcR+vZhvaqI5jaHhuyg2LRzOYQ==",
+      "version": "8.239.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.239.0.tgz",
+      "integrity": "sha512-DeuvLlV7LtGBGEVLfL/PsnM6vKt2YPR6k7IfEoNZHY4RMyQiDB1YlTWor/+lhhRIp4JT3+SxX3BjyDzqVfcAVw==",
       "peer": true
     },
     "node_modules/bitmovin-player-ui": {
@@ -10718,9 +10718,9 @@
       "dev": true
     },
     "bitmovin-player": {
-      "version": "8.161.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.161.0.tgz",
-      "integrity": "sha512-P5sx3KOW4FH23abGOzhDmJHIq1KXXzQpd6MFPmKNDD849p2DKkThxXOyTafQdcR+vZhvaqI5jaHhuyg2LRzOYQ==",
+      "version": "8.239.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.239.0.tgz",
+      "integrity": "sha512-DeuvLlV7LtGBGEVLfL/PsnM6vKt2YPR6k7IfEoNZHY4RMyQiDB1YlTWor/+lhhRIp4JT3+SxX3BjyDzqVfcAVw==",
       "peer": true
     },
     "bitmovin-player-ui": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       },
       "peerDependencies": {
         "bitmovin-player": "^8.0.0",
-        "bitmovin-player-ui": "^3.60.0",
+        "bitmovin-player-ui": "^3 || ^4",
         "react": "^17.0.0 || ^18.0.0"
       }
     },
@@ -2400,9 +2400,10 @@
       "peer": true
     },
     "node_modules/bitmovin-player-ui": {
-      "version": "3.60.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player-ui/-/bitmovin-player-ui-3.60.0.tgz",
-      "integrity": "sha512-NlLotUplZRw6YU488IvmoWRNnonFGUp4yPsvBn7VCYteg5Z3LEk08kkU+i5jUhR4NMzMu//cF68KA4hwIcQFJQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player-ui/-/bitmovin-player-ui-4.5.0.tgz",
+      "integrity": "sha512-SMyCqL1o1+h4KQChnSeka6vaPzMkWH9plg61FlLEUOespY+ZeVeCGsAUpZVPT/gDdaiZ98W7u/C5C0Nak79roA==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/brace-expansion": {
@@ -10723,9 +10724,9 @@
       "peer": true
     },
     "bitmovin-player-ui": {
-      "version": "3.60.0",
-      "resolved": "https://registry.npmjs.org/bitmovin-player-ui/-/bitmovin-player-ui-3.60.0.tgz",
-      "integrity": "sha512-NlLotUplZRw6YU488IvmoWRNnonFGUp4yPsvBn7VCYteg5Z3LEk08kkU+i5jUhR4NMzMu//cF68KA4hwIcQFJQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player-ui/-/bitmovin-player-ui-4.5.0.tgz",
+      "integrity": "sha512-SMyCqL1o1+h4KQChnSeka6vaPzMkWH9plg61FlLEUOespY+ZeVeCGsAUpZVPT/gDdaiZ98W7u/C5C0Nak79roA==",
       "peer": true
     },
     "brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "bitmovin-player": "^8.0.0",
-    "bitmovin-player-ui": "^3.60.0",
+    "bitmovin-player-ui": "^3 || ^4",
     "react": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {

--- a/src/BitmovinPlayer.test.tsx
+++ b/src/BitmovinPlayer.test.tsx
@@ -282,14 +282,20 @@ describe('BitmovinPlayer', () => {
     it('should not initialize any UI when disabled', () => {
       jest.spyOn(UIFactory, 'buildUI');
 
-      render(
+      const { getBySelector } = render(
         <BitmovinPlayer
           config={{
             ...playerConfig,
             ui: false,
           }}
         />,
+        {
+          queries,
+        },
       );
+
+      expect(getBySelector('.bmpui-ui-buffering-overlay')).not.toBeInTheDocument();
+      expect(getBySelector('.bmpui-ui-playbacktoggle-overlay')).not.toBeInTheDocument();
 
       expect(UIFactory.buildUI).not.toHaveBeenCalled();
     });

--- a/src/BitmovinPlayer.test.tsx
+++ b/src/BitmovinPlayer.test.tsx
@@ -172,10 +172,12 @@ describe('BitmovinPlayer', () => {
         it('should initialize using a UIContainer factory', () => {
           jest.spyOn(UIFactory, 'buildUI');
 
-          const uiContainerFactory = () =>
-            new UIContainer({
-              components: [new PlaybackToggleOverlay()],
-            });
+          const uiContainerFactory = jest.fn(
+            () =>
+              new UIContainer({
+                components: [new PlaybackToggleOverlay()],
+              }),
+          );
 
           render(
             <BitmovinPlayer
@@ -187,19 +189,20 @@ describe('BitmovinPlayer', () => {
           );
 
           expect(UIFactory.buildUI).not.toHaveBeenCalled();
+          expect(uiContainerFactory).toHaveBeenCalled();
         });
 
         it('should initialize using a UIVariant[] factory', () => {
           jest.spyOn(UIFactory, 'buildUI');
 
-          const uiVariantsFactory = (): UIVariant[] => [
+          const uiVariantsFactory = jest.fn((): UIVariant[] => [
             {
               ui: new UIContainer({
                 components: [new PlaybackToggleOverlay()],
               }),
               condition: context => !context.isFullscreen,
             },
-          ];
+          ]);
 
           render(
             <BitmovinPlayer
@@ -211,6 +214,7 @@ describe('BitmovinPlayer', () => {
           );
 
           expect(UIFactory.buildUI).not.toHaveBeenCalled();
+          expect(uiVariantsFactory).toHaveBeenCalled();
         });
       });
 

--- a/src/BitmovinPlayer.test.tsx
+++ b/src/BitmovinPlayer.test.tsx
@@ -7,10 +7,23 @@ jest.mock('bitmovin-player', () => {
   };
 });
 
+// Mock UIFactory to spy on UI initialization method
+const mockBuildUI = jest.fn();
+
+jest.mock('bitmovin-player-ui', () => {
+  const actual = jest.requireActual('bitmovin-player-ui');
+  return {
+    ...actual,
+    UIFactory: {
+      buildUI: mockBuildUI,
+    },
+  };
+});
+
 import { render, waitFor } from '@testing-library/react';
 import { PlayerAPI, PlayerConfig, SourceConfig } from 'bitmovin-player';
 import { PlaybackToggleOverlay, TitleBar, UIContainer } from 'bitmovin-player-ui';
-import { UIManager, UIVariant } from 'bitmovin-player-ui/dist/js/framework/uimanager.js';
+import { UIManager, UIVariant } from 'bitmovin-player-ui/dist/js/framework/UIManager.js';
 import { MutableRefObject, RefCallback, StrictMode } from 'react';
 
 import { BitmovinPlayer } from './BitmovinPlayer.js';
@@ -27,6 +40,9 @@ const playerSource: SourceConfig = {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockBuildUI.mockImplementation((player, config) => {
+    return new UIManager(player, new UIContainer({ components: [] }), config);
+  });
 });
 
 describe('BitmovinPlayer', () => {
@@ -121,163 +137,174 @@ describe('BitmovinPlayer', () => {
   });
 
   describe('UI', () => {
-    // Some default UI elements, not the full list.
-    const defaultUiElementSelectors = [
-      '.bmpui-ui-subtitle-overlay',
-      '.bmpui-ui-buffering-overlay',
-      '.bmpui-ui-cast-status-overlay',
-      '.bmpui-ui-controlbar',
-      '.bmpui-ui-titlebar',
-      '.bmpui-ui-recommendation-overlay',
-      '.bmpui-ui-watermark',
-    ];
+    describe('Default UI', () => {
+      describe('Initialization', () => {
+        it('should initialize the default UI', async () => {
+          render(<BitmovinPlayer config={playerConfig} />);
 
-    it('should initialize the default UI', async () => {
-      const { getBySelector } = render(<BitmovinPlayer config={playerConfig} />, {
-        queries,
-      });
-
-      defaultUiElementSelectors.forEach(selector => {
-        expect(getBySelector(selector)).toBeInTheDocument();
-      });
-    });
-
-    it('should initialize the default UI with the provided UI config', () => {
-      const { getBySelector } = render(
-        <BitmovinPlayer
-          config={{
-            ...playerConfig,
-            ui: {
-              metadata: {
-                title: 'Sintel',
-                description: 'A short film by Blender Foundation',
-              },
-            },
-          }}
-        />,
-        {
-          queries,
-        },
-      );
-
-      expect(getBySelector('.bmpui-ui-titlebar')).toBeInTheDocument();
-
-      expect(getBySelector('.bmpui-label-metadata-title')).toBeInTheDocument();
-      expect(getBySelector('.bmpui-label-metadata-title')).toHaveTextContent('Sintel');
-
-      expect(getBySelector('.bmpui-label-metadata-description')).toBeInTheDocument();
-      expect(getBySelector('.bmpui-label-metadata-description')).toHaveTextContent(
-        'A short film by Blender Foundation',
-      );
-    });
-
-    it('should initialize the UI using the `UIContainer`', () => {
-      const uiContainerFactory = () =>
-        new UIContainer({
-          components: [new PlaybackToggleOverlay()],
+          expect(mockBuildUI).toHaveBeenCalledTimes(1);
+          expect(mockBuildUI).toHaveBeenCalledWith(expect.any(FakePlayer), undefined);
         });
 
-      const { getBySelector } = render(
-        <BitmovinPlayer
-          config={playerConfig}
-          customUi={{
-            containerFactory: uiContainerFactory,
-          }}
-        />,
-        {
-          queries,
-        },
-      );
+        it('should initialize with the provided UI config', () => {
+          const uiConfig = {
+            metadata: {
+              title: 'Sintel',
+              description: 'A short film by Blender Foundation',
+            },
+          };
 
-      expect(getBySelector('.bmpui-ui-hugeplaybacktogglebutton')).toBeInTheDocument();
+          render(
+            <BitmovinPlayer
+              config={{
+                ...playerConfig,
+                ui: uiConfig,
+              }}
+            />,
+          );
 
-      defaultUiElementSelectors.forEach(selector => {
-        expect(getBySelector(selector)).not.toBeInTheDocument();
+          expect(mockBuildUI).toHaveBeenCalledTimes(1);
+          expect(mockBuildUI).toHaveBeenCalledWith(expect.any(FakePlayer), uiConfig);
+        });
       });
-    });
 
-    it('should initialize the UI using the `UIVariant[]`', () => {
-      const uiVariantsFactory = (): UIVariant[] => [
-        {
-          ui: new UIContainer({
-            components: [new PlaybackToggleOverlay()],
-          }),
-          condition: context => !context.isFullscreen,
-        },
-      ];
-
-      const { getBySelector } = render(
-        <BitmovinPlayer
-          config={playerConfig}
-          customUi={{
-            variantsFactory: uiVariantsFactory,
-          }}
-        />,
-        {
-          queries,
-        },
-      );
-
-      expect(getBySelector('.bmpui-ui-hugeplaybacktogglebutton')).toBeInTheDocument();
-
-      defaultUiElementSelectors.forEach(selector => {
-        expect(getBySelector(selector)).not.toBeInTheDocument();
-      });
-    });
-
-    it('should initialize the custom UI with the provided UI config', () => {
-      const uiContainerFactory = () =>
-        new UIContainer({
-          components: [new TitleBar()],
+      describe('Rendering', () => {
+        beforeEach(() => {
+          const realUIFactory = jest.requireActual<typeof import('bitmovin-player-ui')>('bitmovin-player-ui').UIFactory;
+          mockBuildUI.mockImplementation(realUIFactory.buildUI);
         });
 
-      const { getBySelector } = render(
-        <BitmovinPlayer
-          config={{
-            ...playerConfig,
-            ui: {
-              metadata: {
-                title: 'Sintel',
-                description: 'A short film by Blender Foundation',
-              },
-            },
-          }}
-          customUi={{
-            containerFactory: uiContainerFactory,
-          }}
-        />,
-        {
-          queries,
-        },
-      );
+        it('should render minimal UI elements before source is loaded (v4 behavior)', () => {
+          const { getBySelector } = render(<BitmovinPlayer config={playerConfig} />, {
+            queries,
+          });
 
-      expect(getBySelector('.bmpui-ui-titlebar')).toBeInTheDocument();
-
-      expect(getBySelector('.bmpui-label-metadata-title')).toBeInTheDocument();
-      expect(getBySelector('.bmpui-label-metadata-title')).toHaveTextContent('Sintel');
-
-      expect(getBySelector('.bmpui-label-metadata-description')).toBeInTheDocument();
-      expect(getBySelector('.bmpui-label-metadata-description')).toHaveTextContent(
-        'A short film by Blender Foundation',
-      );
+          expect(getBySelector('.bmpui-ui-buffering-overlay')).toBeInTheDocument();
+          expect(getBySelector('.bmpui-ui-playbacktoggle-overlay')).toBeInTheDocument();
+        });
+      });
     });
 
-    it('should not initialize any UI', () => {
-      const { getBySelector } = render(
+    describe('Custom UI', () => {
+      describe('Initialization', () => {
+        it('should initialize using a UIContainer factory', () => {
+          const uiContainerFactory = () =>
+            new UIContainer({
+              components: [new PlaybackToggleOverlay()],
+            });
+
+          render(
+            <BitmovinPlayer
+              config={playerConfig}
+              customUi={{
+                containerFactory: uiContainerFactory,
+              }}
+            />,
+          );
+
+          expect(mockBuildUI).not.toHaveBeenCalled();
+        });
+
+        it('should initialize using a UIVariant[] factory', () => {
+          const uiVariantsFactory = (): UIVariant[] => [
+            {
+              ui: new UIContainer({
+                components: [new PlaybackToggleOverlay()],
+              }),
+              condition: context => !context.isFullscreen,
+            },
+          ];
+
+          render(
+            <BitmovinPlayer
+              config={playerConfig}
+              customUi={{
+                variantsFactory: uiVariantsFactory,
+              }}
+            />,
+          );
+
+          expect(mockBuildUI).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('Rendering', () => {
+        beforeEach(() => {
+          const realUIFactory = jest.requireActual<typeof import('bitmovin-player-ui')>('bitmovin-player-ui').UIFactory;
+          mockBuildUI.mockImplementation(realUIFactory.buildUI);
+        });
+
+        it('should render custom UI components correctly', () => {
+          const uiContainerFactory = () =>
+            new UIContainer({
+              components: [new TitleBar()],
+            });
+
+          const { getBySelector } = render(
+            <BitmovinPlayer
+              config={playerConfig}
+              customUi={{
+                containerFactory: uiContainerFactory,
+              }}
+            />,
+            {
+              queries,
+            },
+          );
+
+          expect(getBySelector('.bmpui-ui-titlebar')).toBeInTheDocument();
+        });
+
+        it('should render custom UI with the provided UI config', () => {
+          const uiContainerFactory = () =>
+            new UIContainer({
+              components: [new TitleBar()],
+            });
+
+          const { getBySelector } = render(
+            <BitmovinPlayer
+              config={{
+                ...playerConfig,
+                ui: {
+                  metadata: {
+                    title: 'Sintel',
+                    description: 'A short film by Blender Foundation',
+                  },
+                },
+              }}
+              customUi={{
+                containerFactory: uiContainerFactory,
+              }}
+            />,
+            {
+              queries,
+            },
+          );
+
+          expect(getBySelector('.bmpui-ui-titlebar')).toBeInTheDocument();
+
+          expect(getBySelector('.bmpui-label-metadata-title')).toBeInTheDocument();
+          expect(getBySelector('.bmpui-label-metadata-title')).toHaveTextContent('Sintel');
+
+          expect(getBySelector('.bmpui-label-metadata-description')).toBeInTheDocument();
+          expect(getBySelector('.bmpui-label-metadata-description')).toHaveTextContent(
+            'A short film by Blender Foundation',
+          );
+        });
+      });
+    });
+
+    it('should not initialize any UI when disabled', () => {
+      render(
         <BitmovinPlayer
           config={{
             ...playerConfig,
             ui: false,
           }}
         />,
-        {
-          queries,
-        },
       );
 
-      defaultUiElementSelectors.forEach(selector => {
-        expect(getBySelector(selector)).not.toBeInTheDocument();
-      });
+      expect(mockBuildUI).not.toHaveBeenCalled();
     });
 
     describe('Cleanup', () => {

--- a/src/BitmovinPlayer.test.tsx
+++ b/src/BitmovinPlayer.test.tsx
@@ -7,22 +7,9 @@ jest.mock('bitmovin-player', () => {
   };
 });
 
-// Mock UIFactory to spy on UI initialization method
-const mockBuildUI = jest.fn();
-
-jest.mock('bitmovin-player-ui', () => {
-  const actual = jest.requireActual('bitmovin-player-ui');
-  return {
-    ...actual,
-    UIFactory: {
-      buildUI: mockBuildUI,
-    },
-  };
-});
-
 import { render, waitFor } from '@testing-library/react';
 import { PlayerAPI, PlayerConfig, SourceConfig } from 'bitmovin-player';
-import { PlaybackToggleOverlay, TitleBar, UIContainer } from 'bitmovin-player-ui';
+import { PlaybackToggleOverlay, TitleBar, UIContainer, UIFactory } from 'bitmovin-player-ui';
 import { UIManager, UIVariant } from 'bitmovin-player-ui/dist/js/framework/UIManager.js';
 import { MutableRefObject, RefCallback, StrictMode } from 'react';
 
@@ -40,9 +27,6 @@ const playerSource: SourceConfig = {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockBuildUI.mockImplementation((player, config) => {
-    return new UIManager(player, new UIContainer({ components: [] }), config);
-  });
 });
 
 describe('BitmovinPlayer', () => {
@@ -140,10 +124,11 @@ describe('BitmovinPlayer', () => {
     describe('Default UI', () => {
       describe('Initialization', () => {
         it('should initialize the default UI', async () => {
+          jest.spyOn(UIFactory, 'buildUI');
           render(<BitmovinPlayer config={playerConfig} />);
 
-          expect(mockBuildUI).toHaveBeenCalledTimes(1);
-          expect(mockBuildUI).toHaveBeenCalledWith(expect.any(FakePlayer), undefined);
+          expect(UIFactory.buildUI).toHaveBeenCalledTimes(1);
+          expect(UIFactory.buildUI).toHaveBeenCalledWith(expect.any(FakePlayer), undefined);
         });
 
         it('should initialize with the provided UI config', () => {
@@ -154,6 +139,8 @@ describe('BitmovinPlayer', () => {
             },
           };
 
+          jest.spyOn(UIFactory, 'buildUI');
+
           render(
             <BitmovinPlayer
               config={{
@@ -163,17 +150,12 @@ describe('BitmovinPlayer', () => {
             />,
           );
 
-          expect(mockBuildUI).toHaveBeenCalledTimes(1);
-          expect(mockBuildUI).toHaveBeenCalledWith(expect.any(FakePlayer), uiConfig);
+          expect(UIFactory.buildUI).toHaveBeenCalledTimes(1);
+          expect(UIFactory.buildUI).toHaveBeenCalledWith(expect.any(FakePlayer), uiConfig);
         });
       });
 
       describe('Rendering', () => {
-        beforeEach(() => {
-          const realUIFactory = jest.requireActual<typeof import('bitmovin-player-ui')>('bitmovin-player-ui').UIFactory;
-          mockBuildUI.mockImplementation(realUIFactory.buildUI);
-        });
-
         it('should render minimal UI elements before source is loaded (v4 behavior)', () => {
           const { getBySelector } = render(<BitmovinPlayer config={playerConfig} />, {
             queries,
@@ -188,6 +170,8 @@ describe('BitmovinPlayer', () => {
     describe('Custom UI', () => {
       describe('Initialization', () => {
         it('should initialize using a UIContainer factory', () => {
+          jest.spyOn(UIFactory, 'buildUI');
+
           const uiContainerFactory = () =>
             new UIContainer({
               components: [new PlaybackToggleOverlay()],
@@ -202,10 +186,12 @@ describe('BitmovinPlayer', () => {
             />,
           );
 
-          expect(mockBuildUI).not.toHaveBeenCalled();
+          expect(UIFactory.buildUI).not.toHaveBeenCalled();
         });
 
         it('should initialize using a UIVariant[] factory', () => {
+          jest.spyOn(UIFactory, 'buildUI');
+
           const uiVariantsFactory = (): UIVariant[] => [
             {
               ui: new UIContainer({
@@ -224,16 +210,11 @@ describe('BitmovinPlayer', () => {
             />,
           );
 
-          expect(mockBuildUI).not.toHaveBeenCalled();
+          expect(UIFactory.buildUI).not.toHaveBeenCalled();
         });
       });
 
       describe('Rendering', () => {
-        beforeEach(() => {
-          const realUIFactory = jest.requireActual<typeof import('bitmovin-player-ui')>('bitmovin-player-ui').UIFactory;
-          mockBuildUI.mockImplementation(realUIFactory.buildUI);
-        });
-
         it('should render custom UI components correctly', () => {
           const uiContainerFactory = () =>
             new UIContainer({
@@ -295,6 +276,8 @@ describe('BitmovinPlayer', () => {
     });
 
     it('should not initialize any UI when disabled', () => {
+      jest.spyOn(UIFactory, 'buildUI');
+
       render(
         <BitmovinPlayer
           config={{
@@ -304,7 +287,7 @@ describe('BitmovinPlayer', () => {
         />,
       );
 
-      expect(mockBuildUI).not.toHaveBeenCalled();
+      expect(UIFactory.buildUI).not.toHaveBeenCalled();
     });
 
     describe('Cleanup', () => {

--- a/src/BitmovinPlayer.tsx
+++ b/src/BitmovinPlayer.tsx
@@ -153,8 +153,7 @@ function initializePlayerUi(player: PlayerAPI, playerConfig: PlayerConfig, custo
 
   // If a custom UIManager Factory method was configured through the PlayerConfig, use it directly to not break
   // suggested PlayerConfig usage.
-  if (playerConfig.style && 'uiManagerFactory' in playerConfig.style) {
-    // @ts-expect-error The StyleConfig.uiManagerFactory is only available since Player version 8.226.0
+  if (playerConfig.style && 'uiManagerFactory' in playerConfig.style && playerConfig.style.uiManagerFactory) {
     return playerConfig.style.uiManagerFactory(player, playerConfig.ui);
   }
 

--- a/src/BitmovinPlayer.tsx
+++ b/src/BitmovinPlayer.tsx
@@ -1,4 +1,4 @@
-import { Player, PlayerAPI, PlayerConfig, SourceConfig } from 'bitmovin-player';
+import { Player, PlayerAPI, PlayerConfig, SourceConfig, UIConfig } from 'bitmovin-player';
 import { UIContainer, UIFactory, UIManager, UIVariant } from 'bitmovin-player-ui';
 import {
   ForwardedRef,
@@ -13,7 +13,11 @@ import {
 
 export type UiContainerFactory = () => UIContainer;
 export type UiVariantsFactory = () => UIVariant[];
-export type CustomUi = { containerFactory: UiContainerFactory } | { variantsFactory: UiVariantsFactory };
+export type UiManagerFactory = (player: PlayerAPI, config: UIConfig) => UIManager;
+export type CustomUi =
+  | { containerFactory: UiContainerFactory }
+  | { variantsFactory: UiVariantsFactory }
+  | { managerFactory: UiManagerFactory };
 
 export interface BitmovinPlayerProps {
   config: PlayerConfig;
@@ -147,15 +151,31 @@ function initializePlayerUi(player: PlayerAPI, playerConfig: PlayerConfig, custo
     return;
   }
 
+  // If a custom UIManager Factory method was configured through the PlayerConfig, use it directly to not break
+  // suggested PlayerConfig usage.
+  if (playerConfig.style && 'uiManagerFactory' in playerConfig.style) {
+    // @ts-expect-error The StyleConfig.uiManagerFactory is only available since Player version 8.226.0
+    return playerConfig.style.uiManagerFactory(player, playerConfig.ui);
+  }
+
+  // If a custom UIManager Factory method is provided on the React wrapper, use it instead of the default UI.
+  if (customUi && 'managerFactory' in customUi) {
+    return customUi.managerFactory(player, playerConfig.ui);
+  }
   // If a custom UI container is provided, use it instead of the default UI.
-  if (customUi && 'containerFactory' in customUi) {
+  else if (customUi && 'containerFactory' in customUi) {
     return new UIManager(player, customUi.containerFactory(), playerConfig.ui);
   }
   // If custom UI variants are provided, use them instead of the default UI.
   else if (customUi && 'variantsFactory' in customUi) {
     return new UIManager(player, customUi.variantsFactory(), playerConfig.ui);
-  } else {
+  } else if ('buildDefaultUI' in UIFactory) {
+    // UI v3 is loaded
+    // @ts-expect-error In UI v3 the method was called buildDefaultUI
     return UIFactory.buildDefaultUI(player, playerConfig.ui);
+  } else {
+    // Initializing the default UI from v4
+    return UIFactory.buildUI(player, playerConfig.ui);
   }
 }
 

--- a/src/BitmovinPlayer.tsx
+++ b/src/BitmovinPlayer.tsx
@@ -161,21 +161,25 @@ function initializePlayerUi(player: PlayerAPI, playerConfig: PlayerConfig, custo
   if (customUi && 'managerFactory' in customUi) {
     return customUi.managerFactory(player, playerConfig.ui);
   }
+
   // If a custom UI container is provided, use it instead of the default UI.
-  else if (customUi && 'containerFactory' in customUi) {
+  if (customUi && 'containerFactory' in customUi) {
     return new UIManager(player, customUi.containerFactory(), playerConfig.ui);
   }
+
   // If custom UI variants are provided, use them instead of the default UI.
-  else if (customUi && 'variantsFactory' in customUi) {
+  if (customUi && 'variantsFactory' in customUi) {
     return new UIManager(player, customUi.variantsFactory(), playerConfig.ui);
-  } else if ('buildDefaultUI' in UIFactory) {
+  }
+
+  if ('buildDefaultUI' in UIFactory) {
     // UI v3 is loaded
     // @ts-expect-error In UI v3 the method was called buildDefaultUI
     return UIFactory.buildDefaultUI(player, playerConfig.ui);
-  } else {
-    // Initializing the default UI from v4
-    return UIFactory.buildUI(player, playerConfig.ui);
   }
+
+  // Initializing the default UI from v4
+  return UIFactory.buildUI(player, playerConfig.ui);
 }
 
 function convertConfig(originalConfig: PlayerConfig) {


### PR DESCRIPTION
## Description
We release [Bitmovin Player Web UI v4](https://developer.bitmovin.com/playback/docs/whats-new-in-ui-v4) earler this year. This PR adds support to the React wrapper to use UI v4.

_UI v3 is still supported and can continue to be used._